### PR TITLE
Support single multi-valued expression

### DIFF
--- a/codegen.go
+++ b/codegen.go
@@ -103,15 +103,12 @@ func genStmt(stmt statement) {
 func genExpr(expr expression) {
 	switch e := expr.(type) {
 	case *funcCall:
-
-		fmt.Printf("\tsub rsp, %d\n", e.resultsSize)
-
+		fmt.Printf("\tsub rsp, %d\n", e.target.resultsSize)
 		for _, arg := range e.args {
 			genExpr(arg)
 		}
-
 		fmt.Printf("\tcall %s\n", e.name)
-		fmt.Printf("\tadd rsp, %d\n", e.paramsSize)
+		fmt.Printf("\tadd rsp, %d\n", e.target.paramsSize)
 	case *intLit:
 		fmt.Printf("\tpush %d\n", e.val)
 	case *obj:

--- a/test.sh
+++ b/test.sh
@@ -35,7 +35,6 @@ assert 1 'func main() int { return 100 != 50 }'
 
 assert 2 'func main() int { 1; return 2; }'
 assert 1 'func main() int { return 1; 2; }'
-assert 3 'func main() int { return 1, 3; }'
 assert 2 'func main() int { return (1 + 3) / 2 }'
 
 echo "local variables"

--- a/type.go
+++ b/type.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"fmt"
+)
+
+type typeKind int
+
+const (
+	typeKindInt typeKind = iota
+	typeKindBool
+	typeKindPtr
+)
+
+type typ struct {
+	kind typeKind
+	base *typ
+	size int
+}
+
+func newType(kind typeKind, size int) *typ {
+	return &typ{kind: kind, size: size}
+}
+
+var (
+	typeKindMap = map[string]typeKind{
+		"int":  typeKindInt,
+		"bool": typeKindBool,
+	}
+	typeKindSize = map[string]int{
+		"int":  8,
+		"bool": 8,
+	}
+)
+
+func newLiteralType(s string) *typ {
+	return newType(typeKindMap[s], typeKindSize[s])
+}
+
+func pointerTo(base *typ) *typ {
+	ty := newType(typeKindPtr, 8)
+	ty.base = base
+	return ty
+}
+
+func addType(n interface{}) {
+	if n == nil {
+		return
+	}
+	if n, ok := n.(interface{ getType() *typ }); ok && n.getType() != nil {
+		return
+	}
+
+	switch n := n.(type) {
+	case *returnStmt:
+		addType(n.child)
+		return
+	case *blockStmt:
+		for _, stmt := range n.stmts {
+			addType(stmt)
+		}
+		return
+	case *ifStmt:
+		addType(n.init)
+		addType(n.cond)
+		addType(n.then)
+		addType(n.els)
+		return
+	case *forStmt:
+		addType(n.init)
+		addType(n.cond)
+		addType(n.post)
+		addType(n.body)
+		return
+	case *expressionStmt:
+		addType(n.child)
+		return
+	case *assignment:
+		if se := n.rhs.singleMultiValuedExpression(); se != nil {
+			addType(se)
+			for i, e := range se.multiValues() {
+				n.lhs[i].setType(e.getType())
+			}
+		} else {
+			for i, e := range n.rhs {
+				addType(e)
+				n.lhs[i].setType(e.getType())
+			}
+		}
+		return
+	case *intLit:
+		n.setType(newLiteralType("int"))
+		return
+	case *binary:
+		addType(n.lhs)
+		addType(n.rhs)
+		switch n.op {
+		case "+", "-", "*", "/":
+			n.setType(n.lhs.getType())
+		case "==", "!=", "<", "<=":
+			n.setType(newLiteralType("bool"))
+		}
+		return
+	case *obj:
+		return
+	case *deref:
+		addType(n.child)
+		n.setType(n.child.getType())
+		return
+	case *addr:
+		addType(n.child)
+		ct := n.child.getType()
+		ty := pointerTo(ct)
+		n.setType(ty)
+	case *funcCall:
+		for _, arg := range n.args {
+			addType(arg)
+		}
+		if len(n.target.results) > 0 {
+			n.setType(n.target.results[0].getType())
+		}
+		return
+	default:
+		panic(fmt.Sprintf("Unsupported type: %T", n))
+	}
+}


### PR DESCRIPTION
> A tuple assignment assigns the individual elements of a multi-valued operation to a list of variables.
There are two forms. In the first, the right hand operand is a single multi-valued expression such as a function call,
a [channel](https://go.dev/ref/spec#Channel_types) or [map](https://go.dev/ref/spec#Map_types) operation, or a [type assertion](https://go.dev/ref/spec#Type_assertions).